### PR TITLE
Rename gem to paypal-rest-api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in paypal-api.gemspec
+# Specify your gem's dependencies in paypal-rest-api.gemspec
 gemspec
 
 gem "rspec", "~> 3.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    paypal-api (0.0.1)
+    paypal-rest-api (0.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -119,7 +119,7 @@ PLATFORMS
 
 DEPENDENCIES
   mdl (~> 0.13.0)
-  paypal-api!
+  paypal-rest-api!
   rspec (~> 3.13)
   rubocop (~> 1.64)
   rubocop-rake (~> 0.6)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```bash
-bundle add paypal-api
+bundle add paypal-rest-api
 ```
 
 ## Features

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,7 +29,7 @@
 1. Make local gem release
 
     ```
-    gem build serega.gemspec
+    gem build paypal-rest-api.gemspec
     ```
 
 1. Repeat
@@ -70,5 +70,5 @@
 1. Push new gem version
 
     ```
-    gem push paypal-api-$(cat "VERSION").gem
+    gem push paypal-rest-api-$(cat "VERSION").gem
     ```

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "paypal-api"
+require "paypal-rest-api"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/gemfiles/old.gemfile
+++ b/gemfiles/old.gemfile
@@ -10,4 +10,4 @@ gem "timecop", "~> 0.9"
 
 gem "addressable", "2.8.6"
 
-gemspec name: "paypal-api", path: "../"
+gemspec name: "paypal-rest-api", path: "../"

--- a/gemfiles/old.gemfile.lock
+++ b/gemfiles/old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    paypal-api (0.0.1)
+    paypal-rest-api (0.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -43,7 +43,7 @@ PLATFORMS
 
 DEPENDENCIES
   addressable (= 2.8.6)
-  paypal-api!
+  paypal-rest-api!
   rspec (~> 3.11)
   timecop (~> 0.9)
   webmock (~> 3.23)

--- a/lib/paypal-api.rb
+++ b/lib/paypal-api.rb
@@ -21,29 +21,6 @@ module PaypalAPI
       end
     end
 
-    # DEPRECATED
-    #
-    # billing_agreements
-    # billing_plans
-    # invoices_v1
-    # orders_v1
-    # partner_referrals_v1
-    # payments_v1
-
-    # NOT ADDED YET
-    #
-    # shipment_tracking
-    # catalog_products
-    # disputes
-    # identity
-    # invoices
-    # partner_referrals
-    # payment_experience
-    # payment_method_tokens
-    # payounts
-    # referenced_payouts
-    # subscriptions
-    # transaction_search
     %i[
       authorization
       orders

--- a/lib/paypal-rest-api.rb
+++ b/lib/paypal-rest-api.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "paypal-api"

--- a/paypal-rest-api.gemspec
+++ b/paypal-rest-api.gemspec
@@ -3,7 +3,7 @@
 require_relative "lib/paypal-api/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "paypal-api"
+  spec.name = "paypal-rest-api"
   spec.version = PaypalAPI::VERSION
   spec.authors = ["Andrey Glushkov"]
   spec.email = ["aglushkov@shakuro.com"]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require_relative "simplecov_helper"
 require "webmock/rspec"
 WebMock.disable_net_connect!
 
-require "paypal-api"
+require "paypal-rest-api"
 require "support/shared_examples/endpoint"
 
 RSpec.configure do |config|


### PR DESCRIPTION
As `paypal_api` gem exists and it rubygems does not allow to create gem with similar name `paypal-api`