### PR TITLE
Merge old and new query params when preparing request

### DIFF
--- a/lib/paypal-api/request.rb
+++ b/lib/paypal-api/request.rb
@@ -99,7 +99,8 @@ module PaypalAPI
 
     def build_http_uri(path, query)
       uri = URI.join(client.env.api_url, path)
-      uri.query = URI.encode_www_form(query) if query && !query.empty?
+      add_query_params(uri, query)
+
       uri
     end
 
@@ -111,6 +112,20 @@ module PaypalAPI
       unless headers.key?("authorization")
         http_request["authorization"] = client.access_token.authorization_string
       end
+    end
+
+    def add_query_params(uri, query)
+      return if !query || query.empty?
+
+      # We should merge query params with uri query params to not temove them
+      uri_query_string = uri.query
+
+      if uri_query_string && !uri_query_string.empty?
+        old_query = URI.decode_www_form(uri_query_string).to_h
+        query = old_query.transform_keys!(&:to_sym).merge!(query.transform_keys(&:to_sym))
+      end
+
+      uri.query = URI.encode_www_form(query)
     end
 
     #

--- a/spec/lib/paypal-api/request_spec.rb
+++ b/spec/lib/paypal-api/request_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe PaypalAPI::Request do
     end
   end
 
+  context "with query parameters conflicting with path query parameters" do
+    let(:path) { "path?one=old1&three=3" }
+    let(:query) { {one: 1, two: 2} }
+
+    it "merges query parameters" do
+      http_request = request.http_request
+      expect(http_request.uri).to eq URI("https://api-m.paypal.com/path?one=1&three=3&two=2")
+    end
+  end
+
   context "with custom headers" do
     let(:headers) do
       {:one => 1, "Authorization" => "AUTH", "Content-Type" => "multipart/form-data", "PayPal-Request-Id" => 123}


### PR DESCRIPTION
This will be required when we allow to navigate by HATEOAS links which include query params