### PR TITLE
Add #follow_up_link method to Response object 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 - Add PartnerReferrals APIs collection
 - Add PaymentExperienceWebProfiles APIs collection
 - Add TransactionSearch APIs collection
+- Add Response#follow_up_link method to use HATEOAS link
+- Add Response#each_page method to iterate over pages
+- Add Response#each_page_item(items_field_name) method to iterate over page items
+
+```ruby
+  PaypalAPI::WebhookEvents.list(page_size: 25).each_page do |response|
+    # ...
+  end
+
+  PaypalAPI::WebhookEvents.list(page_size: 25).each_page_item(:events) do |hash|
+    # ...
+  end
+```
 
 ## [0.4.0] - 2024-09-16
 

--- a/lib/paypal-api/client.rb
+++ b/lib/paypal-api/client.rb
@@ -43,28 +43,33 @@ module PaypalAPI
       @access_token = nil
     end
 
-    # Checks if PayPal LIVE environment enabled
-    # @return [Boolean] Checks if PayPal LIVE environment enabled
-    def live?
-      env.live?
-    end
+    #
+    # Environment specific methods
+    #
+    module EnvironmentMethods
+      # Checks if PayPal LIVE environment enabled
+      # @return [Boolean] Checks if PayPal LIVE environment enabled
+      def live?
+        env.live?
+      end
 
-    # Checks if PayPal SANDBOX environment enabled
-    # @return [Boolean] Checks if PayPal SANDBOX environment enabled
-    def sandbox?
-      env.sandbox?
-    end
+      # Checks if PayPal SANDBOX environment enabled
+      # @return [Boolean] Checks if PayPal SANDBOX environment enabled
+      def sandbox?
+        env.sandbox?
+      end
 
-    # Base API URL
-    # @return [String] Base API URL
-    def api_url
-      env.api_url
-    end
+      # Base API URL
+      # @return [String] Base API URL
+      def api_url
+        env.api_url
+      end
 
-    # Base WEB URL
-    # @return [String] Base WEB URL
-    def web_url
-      env.web_url
+      # Base WEB URL
+      # @return [String] Base WEB URL
+      def web_url
+        env.web_url
+      end
     end
 
     # Registers callback
@@ -91,29 +96,35 @@ module PaypalAPI
     end
 
     #
-    # Checks cached access token is expired and returns it or generates new one
+    # Methods to take Access-Token
+    # @api private
     #
-    # @return [AccessToken] AccessToken object
-    #
-    def access_token
-      (@access_token.nil? || @access_token.expired?) ? refresh_access_token : @access_token
-    end
+    module AccessTokenMethods
+      #
+      # Checks cached access token is expired and returns it or generates new one
+      #
+      # @return [AccessToken] AccessToken object
+      #
+      def access_token
+        (@access_token.nil? || @access_token.expired?) ? refresh_access_token : @access_token
+      end
 
-    #
-    # Generates and caches new AccessToken
-    #
-    # @return [AccessToken] new AccessToken object
-    #
-    def refresh_access_token
-      requested_at = Time.now
-      response = authentication.generate_access_token
+      #
+      # Generates and caches new AccessToken
+      #
+      # @return [AccessToken] new AccessToken object
+      #
+      def refresh_access_token
+        requested_at = Time.now
+        response = authentication.generate_access_token
 
-      @access_token = AccessToken.new(
-        requested_at: requested_at,
-        expires_in: response.fetch(:expires_in),
-        access_token: response.fetch(:access_token),
-        token_type: response.fetch(:token_type)
-      )
+        @access_token = AccessToken.new(
+          requested_at: requested_at,
+          expires_in: response.fetch(:expires_in),
+          access_token: response.fetch(:access_token),
+          token_type: response.fetch(:token_type)
+        )
+      end
     end
 
     #
@@ -148,188 +159,203 @@ module PaypalAPI
       WebhookVerifier.new(self).call(webhook_id: webhook_id, headers: headers, raw_body: raw_body)
     end
 
-    # @!macro [new] request
-    # @param path [String] Request path
-    # @param query [Hash, nil] Request query parameters
-    # @param body [Hash, nil] Request body parameters
-    # @param headers [Hash, nil] Request headers
     #
-    # @return [Response] Response object
+    # HTTP methods
+    #
+    module HTTPMethods
+      # @!macro [new] request
+      # @param path [String] Request path
+      # @param query [Hash, nil] Request query parameters
+      # @param body [Hash, nil] Request body parameters
+      # @param headers [Hash, nil] Request headers
+      #
+      # @return [Response] Response object
+
+      #
+      # Executes POST http request
+      #
+      # @macro request
+      #
+      def post(path, query: nil, body: nil, headers: nil)
+        execute_request(Net::HTTP::Post, path, query: query, body: body, headers: headers)
+      end
+
+      #
+      # Executes GET http request
+      #
+      # @macro request
+      #
+      def get(path, query: nil, body: nil, headers: nil)
+        execute_request(Net::HTTP::Get, path, query: query, body: body, headers: headers)
+      end
+
+      #
+      # Executes PATCH http request
+      #
+      # @macro request
+      #
+      def patch(path, query: nil, body: nil, headers: nil)
+        execute_request(Net::HTTP::Patch, path, query: query, body: body, headers: headers)
+      end
+
+      #
+      # Executes PUT http request
+      #
+      # @macro request
+      #
+      def put(path, query: nil, body: nil, headers: nil)
+        execute_request(Net::HTTP::Put, path, query: query, body: body, headers: headers)
+      end
+
+      #
+      # Executes DELETE http request
+      #
+      # @macro request
+      #
+      def delete(path, query: nil, body: nil, headers: nil)
+        execute_request(Net::HTTP::Delete, path, query: query, body: body, headers: headers)
+      end
+    end
 
     #
-    # Executes POST http request
+    # Methods to access API collections
     #
-    # @macro request
-    #
-    def post(path, query: nil, body: nil, headers: nil)
-      execute_request(Net::HTTP::Post, path, query: query, body: body, headers: headers)
+    module APIMethods
+      # @return [AuthorizedPayments] AuthorizedPayments APIs collection
+      def authorized_payments
+        AuthorizedPayments.new(self)
+      end
+
+      # @return [CapturedPayments] CapturedPayments APIs collection
+      def captured_payments
+        CapturedPayments.new(self)
+      end
+
+      # @return [Authentication] Authentication APIs collection
+      def authentication
+        Authentication.new(self)
+      end
+
+      # @return [CatalogProducts] Catalog Products APIs collection
+      def catalog_products
+        CatalogProducts.new(self)
+      end
+
+      # @return [Disputes] Disputes APIs collection
+      def disputes
+        Disputes.new(self)
+      end
+
+      # @return [InvoiceTemplates] InvoiceTemplates APIs collection
+      def invoice_templates
+        InvoiceTemplates.new(self)
+      end
+
+      # @return [Invoices] Invoices APIs collection
+      def invoices
+        Invoices.new(self)
+      end
+
+      # @return [Orders] Orders APIs collection
+      def orders
+        Orders.new(self)
+      end
+
+      # @return [PartnerReferrals] PartnerReferrals APIs collection
+      def partner_referrals
+        PartnerReferrals.new(self)
+      end
+
+      # @return [PaymentExperienceWebProfiles] PaymentExperienceWebProfiles APIs collection
+      def payment_experience_web_profiles
+        PaymentExperienceWebProfiles.new(self)
+      end
+
+      # @return [PaymentTokens] PaymentTokens APIs collection
+      def payment_tokens
+        PaymentTokens.new(self)
+      end
+
+      # @return [PayoutItems] PayoutItems APIs collection
+      def payout_items
+        PayoutItems.new(self)
+      end
+
+      # @return [Payouts] Payouts APIs collection
+      def payouts
+        Payouts.new(self)
+      end
+
+      # @return [Refunds] Refunds APIs collection
+      def refunds
+        Refunds.new(self)
+      end
+
+      # @return [ReferencedPayoutItems] ReferencedPayoutItems APIs collection
+      def referenced_payout_items
+        ReferencedPayoutItems.new(self)
+      end
+
+      # @return [ReferencedPayouts] ReferencedPayouts APIs collection
+      def referenced_payouts
+        ReferencedPayouts.new(self)
+      end
+
+      # @return [SetupTokens] SetupTokens APIs collection
+      def setup_tokens
+        SetupTokens.new(self)
+      end
+
+      # @return [ShipmentTracking] Shipment Tracking APIs collection
+      def shipment_tracking
+        ShipmentTracking.new(self)
+      end
+
+      # @return [Subscriptions] Subscriptions APIs collection
+      def subscriptions
+        Subscriptions.new(self)
+      end
+
+      # @return [SubscriptionPlans] Subscription Plans APIs collection
+      def subscription_plans
+        SubscriptionPlans.new(self)
+      end
+
+      # @return [TransactionSearch] TransactionSearch APIs collection
+      def transaction_search
+        TransactionSearch.new(self)
+      end
+
+      # @return [UserInfo] User Info APIs collection
+      def user_info
+        UserInfo.new(self)
+      end
+
+      # @return [Users] Users Management APIs collection
+      def users
+        Users.new(self)
+      end
+
+      # @return [Webhooks] Webhooks APIs collection
+      def webhooks
+        Webhooks.new(self)
+      end
+
+      # @return [WebhookEvents] Webhook Events APIs collection
+      def webhook_lookups
+        WebhookLookups.new(self)
+      end
+
+      # @return [WebhookEvents] Webhook Lookups APIs collection
+      def webhook_events
+        WebhookEvents.new(self)
+      end
     end
 
-    #
-    # Executes GET http request
-    #
-    # @macro request
-    #
-    def get(path, query: nil, body: nil, headers: nil)
-      execute_request(Net::HTTP::Get, path, query: query, body: body, headers: headers)
-    end
-
-    #
-    # Executes PATCH http request
-    #
-    # @macro request
-    #
-    def patch(path, query: nil, body: nil, headers: nil)
-      execute_request(Net::HTTP::Patch, path, query: query, body: body, headers: headers)
-    end
-
-    #
-    # Executes PUT http request
-    #
-    # @macro request
-    #
-    def put(path, query: nil, body: nil, headers: nil)
-      execute_request(Net::HTTP::Put, path, query: query, body: body, headers: headers)
-    end
-
-    #
-    # Executes DELETE http request
-    #
-    # @macro request
-    #
-    def delete(path, query: nil, body: nil, headers: nil)
-      execute_request(Net::HTTP::Delete, path, query: query, body: body, headers: headers)
-    end
-
-    # @return [AuthorizedPayments] AuthorizedPayments APIs collection
-    def authorized_payments
-      AuthorizedPayments.new(self)
-    end
-
-    # @return [CapturedPayments] CapturedPayments APIs collection
-    def captured_payments
-      CapturedPayments.new(self)
-    end
-
-    # @return [Authentication] Authentication APIs collection
-    def authentication
-      Authentication.new(self)
-    end
-
-    # @return [CatalogProducts] Catalog Products APIs collection
-    def catalog_products
-      CatalogProducts.new(self)
-    end
-
-    # @return [Disputes] Disputes APIs collection
-    def disputes
-      Disputes.new(self)
-    end
-
-    # @return [InvoiceTemplates] InvoiceTemplates APIs collection
-    def invoice_templates
-      InvoiceTemplates.new(self)
-    end
-
-    # @return [Invoices] Invoices APIs collection
-    def invoices
-      Invoices.new(self)
-    end
-
-    # @return [Orders] Orders APIs collection
-    def orders
-      Orders.new(self)
-    end
-
-    # @return [PartnerReferrals] PartnerReferrals APIs collection
-    def partner_referrals
-      PartnerReferrals.new(self)
-    end
-
-    # @return [PaymentExperienceWebProfiles] PaymentExperienceWebProfiles APIs collection
-    def payment_experience_web_profiles
-      PaymentExperienceWebProfiles.new(self)
-    end
-
-    # @return [PaymentTokens] PaymentTokens APIs collection
-    def payment_tokens
-      PaymentTokens.new(self)
-    end
-
-    # @return [PayoutItems] PayoutItems APIs collection
-    def payout_items
-      PayoutItems.new(self)
-    end
-
-    # @return [Payouts] Payouts APIs collection
-    def payouts
-      Payouts.new(self)
-    end
-
-    # @return [Refunds] Refunds APIs collection
-    def refunds
-      Refunds.new(self)
-    end
-
-    # @return [ReferencedPayoutItems] ReferencedPayoutItems APIs collection
-    def referenced_payout_items
-      ReferencedPayoutItems.new(self)
-    end
-
-    # @return [ReferencedPayouts] ReferencedPayouts APIs collection
-    def referenced_payouts
-      ReferencedPayouts.new(self)
-    end
-
-    # @return [SetupTokens] SetupTokens APIs collection
-    def setup_tokens
-      SetupTokens.new(self)
-    end
-
-    # @return [ShipmentTracking] Shipment Tracking APIs collection
-    def shipment_tracking
-      ShipmentTracking.new(self)
-    end
-
-    # @return [Subscriptions] Subscriptions APIs collection
-    def subscriptions
-      Subscriptions.new(self)
-    end
-
-    # @return [SubscriptionPlans] Subscription Plans APIs collection
-    def subscription_plans
-      SubscriptionPlans.new(self)
-    end
-
-    # @return [TransactionSearch] TransactionSearch APIs collection
-    def transaction_search
-      TransactionSearch.new(self)
-    end
-
-    # @return [UserInfo] User Info APIs collection
-    def user_info
-      UserInfo.new(self)
-    end
-
-    # @return [Users] Users Management APIs collection
-    def users
-      Users.new(self)
-    end
-
-    # @return [Webhooks] Webhooks APIs collection
-    def webhooks
-      Webhooks.new(self)
-    end
-
-    # @return [WebhookEvents] Webhook Events APIs collection
-    def webhook_lookups
-      WebhookLookups.new(self)
-    end
-
-    # @return [WebhookEvents] Webhook Lookups APIs collection
-    def webhook_events
-      WebhookEvents.new(self)
-    end
+    include APIMethods
+    include HTTPMethods
+    include EnvironmentMethods
+    include AccessTokenMethods
 
     private
 

--- a/lib/paypal-api/response.rb
+++ b/lib/paypal-api/response.rb
@@ -108,6 +108,29 @@ module PaypalAPI
       "#<#{self.class.name} (#{http_response.code})>"
     end
 
+    #
+    # Follow up HATEOAS link
+    #
+    # @see https://developer.paypal.com/api/rest/responses/#link-hateoaslinks
+    #
+    # @param rel [String] Target link "rel" attribute
+    # @param query [Hash] Request additional query parameters
+    # @param body [Hash] Request body parameters
+    # @param headers [Hash] Request headers
+    #
+    # @return [Response, nil] Follow-up link response, if link with provided "rel" exists
+    #
+    def follow_up_link(rel, query: nil, body: nil, headers: nil)
+      links = self[:links]
+      return unless links
+
+      link = links.find { |curr_link| curr_link[:rel] == rel.to_s }
+      return unless link
+
+      http_method = link[:method]&.downcase || :get
+      request.client.public_send(http_method, link[:href], query: query, body: body, headers: headers)
+    end
+
     private
 
     def json_response?

--- a/spec/lib/paypal-api/response_spec.rb
+++ b/spec/lib/paypal-api/response_spec.rb
@@ -7,14 +7,15 @@ RSpec.describe PaypalAPI::Response do
     instance_double(
       Net::HTTPResponse,
       code: "200",
-      body: body,
+      body: response_body,
       each_header: each_header
     )
   end
 
-  let(:body) { '{"foo":"bar"}' }
+  let(:response_body) { '{"foo":"bar"}' }
   let(:each_header) { {a: 1, b: 2}.each }
-  let(:request) { "REQUEST" }
+  let(:request) { instance_double(PaypalAPI::Request, client: client) }
+  let(:client) { instance_double(PaypalAPI::Client, get: :get_response, post: :post_response) }
 
   before { allow(http_response).to receive(:[]).with("content-type").and_return("application/json") }
 
@@ -24,14 +25,14 @@ RSpec.describe PaypalAPI::Response do
       expect(response.http_headers).to eq(a: 1, b: 2)
       expect(response.http_response).to equal http_response
       expect(response.http_status).to equal 200
-      expect(response.http_body).to equal body
+      expect(response.http_body).to equal response_body
       expect(response.body).to eq(foo: "bar")
       expect(response[:foo]).to eq "bar"
       expect(response.fetch(:foo)).to eq "bar"
     end
 
     context "with non-parsable body" do
-      let(:body) { 123 }
+      let(:response_body) { 123 }
 
       it "returns original http body" do
         expect(response.body).to eq(123)
@@ -47,8 +48,8 @@ RSpec.describe PaypalAPI::Response do
       expect(response.http_headers).to eq(a: 1, b: 2)
       expect(response.http_response).to equal http_response
       expect(response.http_status).to equal 200
-      expect(response.http_body).to equal body
-      expect(response.body).to eq(body)
+      expect(response.http_body).to equal response_body
+      expect(response.body).to eq(response_body)
       expect(response[:foo]).to be_nil
       expect { response.fetch(:foo) }.to raise_error KeyError
     end
@@ -58,6 +59,89 @@ RSpec.describe PaypalAPI::Response do
     it "shows only status" do
       response.body # load body
       expect(response.inspect).to eq "#<PaypalAPI::Response (200)>"
+    end
+  end
+
+  describe "#follow_up_link" do
+    let(:response_body) { JSON.dump(links: links) }
+    let(:query) { "QUERY" }
+    let(:body) { "BODY" }
+    let(:headers) { "HEADERS" }
+
+    context "with GET link" do
+      let(:links) { [{rel: "get_rel", href: "https://api-m.paypal.com/get", method: "GET"}] }
+
+      it "follows up GET link" do
+        expect(response.follow_up_link("get_rel")).to eq :get_response
+
+        expect(client)
+          .to have_received(:get)
+          .with("https://api-m.paypal.com/get", query: nil, body: nil, headers: nil)
+      end
+
+      it "follows up GET link with params" do
+        expect(response.follow_up_link("get_rel", query: query, body: body, headers: headers)).to eq :get_response
+
+        expect(client)
+          .to have_received(:get)
+          .with("https://api-m.paypal.com/get", query: query, body: body, headers: headers)
+      end
+    end
+
+    context "with POST link" do
+      let(:links) { [{rel: "post_rel", href: "https://api-m.paypal.com/post", method: "POST"}] }
+
+      it "follows up POST link" do
+        expect(response.follow_up_link("post_rel")).to eq :post_response
+
+        expect(client)
+          .to have_received(:post)
+          .with("https://api-m.paypal.com/post", query: nil, body: nil, headers: nil)
+      end
+
+      it "follows up POST link with params" do
+        expect(response.follow_up_link("post_rel", query: query, body: body, headers: headers)).to eq :post_response
+
+        expect(client)
+          .to have_received(:post)
+          .with("https://api-m.paypal.com/post", query: query, body: body, headers: headers)
+      end
+    end
+
+    context "with link without method" do
+      let(:links) { [{rel: "get_rel", href: "https://api-m.paypal.com/get"}] }
+
+      it "uses GET method" do
+        expect(response.follow_up_link("get_rel")).to eq :get_response
+
+        expect(client)
+          .to have_received(:get)
+          .with("https://api-m.paypal.com/get", query: nil, body: nil, headers: nil)
+      end
+    end
+
+    context "when response is not a Hash" do
+      let(:response_body) { "foobar" }
+
+      it "returns nil" do
+        expect(response.follow_up_link("get_rel")).to be_nil
+      end
+    end
+
+    context "when response has no links" do
+      let(:response_body) { "{}" }
+
+      it "returns nil" do
+        expect(response.follow_up_link("get_rel")).to be_nil
+      end
+    end
+
+    context "when response has no link with provided rel" do
+      let(:links) { [] }
+
+      it "returns nil" do
+        expect(response.follow_up_link("get_rel")).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Allows to request HATEOAS link from response.

This is most usefull to navigate through list request pages

```ruby
next_page = response.follow_up_link("next") # => [Response] 2nd page response
next_page.follow_up_link("next") # => [Response] # 3rd page respnse
next_page.follow_up_link("next") # => nil, no new pages
```